### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/melisms/paddle/security/code-scanning/1](https://github.com/melisms/paddle/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least privilege by default.

Best fix here: define at workflow root:

- `contents: read` (needed for `actions/checkout`)
- no additional scopes unless required

This preserves existing functionality while ensuring token permissions remain constrained even if org/repo defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
